### PR TITLE
allow disabling SSL and passing ssl headers instead

### DIFF
--- a/jetconf/config.py
+++ b/jetconf/config.py
@@ -36,6 +36,7 @@ class JcConfig:
 
             "SERVER_SSL_CERT": "server.crt",
             "SERVER_SSL_PRIVKEY": "server.key",
+            "DISABLE_SSL": False,
             "CA_CERT": "ca.pem",
             "DBG_DISABLE_CERTS": False
         }

--- a/jetconf/http_handlers.py
+++ b/jetconf/http_handlers.py
@@ -48,6 +48,14 @@ ERRTAG_INVVALUE = "invalid-value"
 ERRTAG_EXISTS = "data-exists"
 
 
+def get_username(client_cert: SSLCertT, headers: OrderedDict) -> str:
+    if config.CFG.http["DISABLE_SSL"]:
+        return headers.get("x-ssl-client-cn")
+    else:
+        return CertHelpers.get_field(client_cert, "emailAddress")
+
+
+
 class HttpRequestError(Exception):
     pass
 
@@ -351,7 +359,7 @@ class HttpHandlersImpl:
         return http_resp
 
     def get_api_running(self, headers: OrderedDict, data: Optional[str], client_cert: SSLCertT) -> HttpResponse:
-        username = CertHelpers.get_field(client_cert, "emailAddress")
+        username = get_username(client_cert, headers)
         info("[{}] api_get_running: {}".format(username, headers[":path"]))
 
         api_pth = headers[":path"][len(config.CFG.api_root_running_data):]
@@ -359,7 +367,7 @@ class HttpHandlersImpl:
         return http_resp
 
     def get_api_staging(self, headers: OrderedDict, data: Optional[str], client_cert: SSLCertT) -> HttpResponse:
-        username = CertHelpers.get_field(client_cert, "emailAddress")
+        username = get_username(client_cert, headers)
         info("[{}] api_get_staging: {}".format(username, headers[":path"]))
 
         api_pth = headers[":path"][len(config.CFG.api_root_data):]
@@ -367,7 +375,7 @@ class HttpHandlersImpl:
         return http_resp
 
     def get_api_op(self, headers: OrderedDict, data: Optional[str], client_cert: SSLCertT) -> HttpResponse:
-        username = CertHelpers.get_field(client_cert, "emailAddress")
+        username = get_username(client_cert, headers)
         info("[{}] get_op: {}".format(username, headers[":path"]))
 
         api_pth = headers[":path"][len(config.CFG.api_root_ops):].rstrip("/")
@@ -416,7 +424,7 @@ class HttpHandlersImpl:
 
     def get_file(self, headers: OrderedDict, data: Optional[str], client_cert: SSLCertT) -> HttpResponse:
         # Ordinary file on filesystem
-        username = CertHelpers.get_field(client_cert, "emailAddress")
+        username = get_username(client_cert, headers)
         url_path = headers[":path"].split("?")[0]
         url_path_safe = "".join(filter(lambda c: c.isalpha() or c in "/-_.", url_path)).replace("..", "").strip("/")
         file_path = os.path.join(config.CFG.http["DOC_ROOT"], url_path_safe)
@@ -596,7 +604,7 @@ class HttpHandlersImpl:
         return http_resp
 
     def post_api(self, headers: OrderedDict, data: Optional[str], client_cert: SSLCertT) -> HttpResponse:
-        username = CertHelpers.get_field(client_cert, "emailAddress")
+        username = get_username(client_cert, headers)
         info("[{}] api_post: {}".format(username, headers[":path"]))
 
         api_pth = headers[":path"][len(config.CFG.api_root_data):]
@@ -677,7 +685,7 @@ class HttpHandlersImpl:
         return http_resp
 
     def put_api(self, headers: OrderedDict, data: Optional[str], client_cert: SSLCertT) -> HttpResponse:
-        username = CertHelpers.get_field(client_cert, "emailAddress")
+        username = get_username(client_cert, headers)
         info("[{}] api_put: {}".format(username, headers[":path"]))
 
         api_pth = headers[":path"][len(config.CFG.api_root_data):]
@@ -745,7 +753,7 @@ class HttpHandlersImpl:
             return http_resp
 
     def delete_api(self, headers: OrderedDict, data: Optional[str], client_cert: SSLCertT) -> HttpResponse:
-        username = CertHelpers.get_field(client_cert, "emailAddress")
+        username = get_username(client_cert, headers)
         info("[{}] api_delete: {}".format(username, headers[":path"]))
 
         api_pth = headers[":path"][len(config.CFG.api_root_data):]
@@ -753,7 +761,7 @@ class HttpHandlersImpl:
         return http_resp
 
     def post_api_op_call(self, headers: OrderedDict, data: Optional[str], client_cert: SSLCertT) -> HttpResponse:
-        username = CertHelpers.get_field(client_cert, "emailAddress")
+        username = get_username(client_cert, headers)
         info("[{}] invoke_op: {}".format(username, headers[":path"]))
 
         api_pth = headers[":path"][len(config.CFG.api_root_ops):]


### PR DESCRIPTION
The idea with this feature is two-fold:

1. Allow disabling SSL
2. When SSL is disabled, read the header `x-ssl-client-cn` to establish the user making the request

This change allows you to run jetconf behind a load balancer like haproxy, where you can terminate the TLS connection and forward the request to jetconf. For instance:

```
frontend https-in
    mode http
    # listen on port 65443 and enable mTLS and http/2
    bind 0.0.0.0:65443 ssl crt /etc/haproxy/rosetta.pem ca-file /etc/haproxy/ca.pem verify optional alpn h2

    # forward SSL headers to jetconf
    http-request set-header X-SSL                       %[ssl_fc]
    http-request set-header X-SSL-Client-Verify         %[ssl_c_verify]
    http-request set-header X-SSL-Client-DN             %{+Q}[ssl_c_s_dn]
    http-request set-header X-SSL-Client-CN             %{+Q}[ssl_c_s_dn(cn)]
    http-request set-header X-SSL-Issuer                %{+Q}[ssl_c_i_dn]
    http-request set-header X-SSL-Client-Not-Before     %{+Q}[ssl_c_notbefore]
    http-request set-header X-SSL-Client-Not-After      %{+Q}[ssl_c_notafter]

    # configure rules to forward requests to the different instances of jetconf
    use_backend rtr00 if { path -i -m beg /rtr00 }
    use_backend rtr01 if { path -i -m beg /rtr01 }


backend rtr00
    mode http

    # remove /rtr0x from the url
    reqrep ^([^\ ]*\ /)rtr00[/]?(.*)     \1\2
    server rtr00 172.21.33.100:8443 proto h2

backend rtr01
    mode http

    # remove /rtr0x from the url
    reqrep ^([^\ ]*\ /)rtr01[/]?(.*)     \1\2
    server rtr00 172.21.33.101:8443 proto h2
```